### PR TITLE
Add sonatype required javadoc and sources packages

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -30,3 +30,18 @@ test {
     dependsOn 'jar'
     classpath = sourceSets.test.runtimeClasspath - files("build/classes/java/main") - files("build/resources/main") + fileTree(dir:"build/libs")
 }
+
+task packageJavadoc(type: Jar, dependsOn: 'javadoc') {
+    from javadoc.destinationDir
+    classifier = 'javadoc'
+}
+
+task packageSources(type: Jar) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
+}
+
+artifacts {
+    archives packageJavadoc
+    archives packageSources
+}


### PR DESCRIPTION
Update the java/build.gradle to include tasks that oss.sonatype.org
requires.