### PR TITLE
Fix description of makeAll task in build.gradle from "Build the android libraries" to "Build all libraries"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ task makeAndroid(type:Exec) {
 
 task makeAll() {
   group 'Rust'
-  description 'Build the android libraries'
+  description 'Build all libraries'
 
   dependsOn 'makeMac', 'makeServer', 'makeAndroid'
 }


### PR DESCRIPTION
Change description from "Build the android libraries" to "Build all libraries" in the makeAll task in build.gradle