### PR TITLE
Bump ref-napi and ref-array-napi to get node-addon-api to v3

### DIFF
--- a/ffi/node/package-lock.json
+++ b/ffi/node/package-lock.json
@@ -10,8 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "ffi-napi": "4.0.3",
-        "ref-array-napi": "1.2.1",
-        "ref-napi": "3.0.2"
+        "ref-array-napi": "1.2.2",
+        "ref-napi": "3.0.3"
       },
       "devDependencies": {
         "@types/chai": "4.2.7",
@@ -480,9 +480,9 @@
       }
     },
     "node_modules/ext/node_modules/type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-      "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+      "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
     },
     "node_modules/ffi-napi": {
       "version": "4.0.3",
@@ -1107,13 +1107,14 @@
       }
     },
     "node_modules/ref-array-napi": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ref-array-napi/-/ref-array-napi-1.2.1.tgz",
-      "integrity": "sha512-jQp2WWSucmxkqVfoNfm7yDlDeGu3liAbzqfwjNybL80ooLOCnCZpAK2woDInY+lxNOK/VlIVSqeDEYb4gVPuNQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ref-array-napi/-/ref-array-napi-1.2.2.tgz",
+      "integrity": "sha512-EGQzUQpyqD/hN9eIn3uF68UPBmwJXdWkumHCmvK3ncjw128bkjd8TbJ51ur+2PZ4UrfCOQCcPQkuWZ6mNHch9A==",
+      "license": "MIT",
       "dependencies": {
         "array-index": "1",
         "debug": "2",
-        "ref-napi": "^1.4.2"
+        "ref-napi": "^3.0.1"
       }
     },
     "node_modules/ref-array-napi/node_modules/debug": {
@@ -1129,47 +1130,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
-    "node_modules/ref-array-napi/node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-    },
-    "node_modules/ref-array-napi/node_modules/ref-napi": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.5.2.tgz",
-      "integrity": "sha512-hwyNmWpUkt1bDWDW4aiwCoC+SJfJO69UIdjqssNqdaS0sYJpgqzosGg/rLtk69UoQ8drZdI9yyQefM7eEMM3Gw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "debug": "^3.1.0",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.1"
-      },
-      "engines": {
-        "node": ">= 6.0"
-      }
-    },
-    "node_modules/ref-array-napi/node_modules/ref-napi/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/ref-array-napi/node_modules/ref-napi/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
     "node_modules/ref-napi": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.2.tgz",
-      "integrity": "sha512-5YE0XrvWteoTr5DR2sEqxefL06aml7c6qS7hGv3u27do4HlGQphwvB+zD1NYep9utMKScvwOZsSs9EPYdGBVsg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
+      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
       "hasInstallScript": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^2.0.0",
+        "node-addon-api": "^3.0.0",
         "node-gyp-build": "^4.2.1"
       },
       "engines": {
@@ -1192,15 +1161,10 @@
         }
       }
     },
-    "node_modules/ref-napi/node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-    },
     "node_modules/ref-struct-di": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.0.tgz",
-      "integrity": "sha512-gghZITj/iQwdwFDduZ6T8kL2B2ogInlOz7AOB0ggFoEc7akAKMcDrbzh3OIPk13Kxy8U2bHPvN6nejcBh4jN7A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
       "dependencies": {
         "debug": "^3.1.0"
       }
@@ -1913,9 +1877,9 @@
       },
       "dependencies": {
         "type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.5.0.tgz",
+          "integrity": "sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw=="
         }
       }
     },
@@ -2399,13 +2363,13 @@
       }
     },
     "ref-array-napi": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ref-array-napi/-/ref-array-napi-1.2.1.tgz",
-      "integrity": "sha512-jQp2WWSucmxkqVfoNfm7yDlDeGu3liAbzqfwjNybL80ooLOCnCZpAK2woDInY+lxNOK/VlIVSqeDEYb4gVPuNQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ref-array-napi/-/ref-array-napi-1.2.2.tgz",
+      "integrity": "sha512-EGQzUQpyqD/hN9eIn3uF68UPBmwJXdWkumHCmvK3ncjw128bkjd8TbJ51ur+2PZ4UrfCOQCcPQkuWZ6mNHch9A==",
       "requires": {
         "array-index": "1",
         "debug": "2",
-        "ref-napi": "^1.4.2"
+        "ref-napi": "^3.0.1"
       },
       "dependencies": {
         "debug": {
@@ -2420,47 +2384,17 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "node-addon-api": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
-        },
-        "ref-napi": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-1.5.2.tgz",
-          "integrity": "sha512-hwyNmWpUkt1bDWDW4aiwCoC+SJfJO69UIdjqssNqdaS0sYJpgqzosGg/rLtk69UoQ8drZdI9yyQefM7eEMM3Gw==",
-          "requires": {
-            "debug": "^3.1.0",
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.1"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.7",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-              "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.3",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-            }
-          }
         }
       }
     },
     "ref-napi": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.2.tgz",
-      "integrity": "sha512-5YE0XrvWteoTr5DR2sEqxefL06aml7c6qS7hGv3u27do4HlGQphwvB+zD1NYep9utMKScvwOZsSs9EPYdGBVsg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/ref-napi/-/ref-napi-3.0.3.tgz",
+      "integrity": "sha512-LiMq/XDGcgodTYOMppikEtJelWsKQERbLQsYm0IOOnzhwE9xYZC7x8txNnFC9wJNOkPferQI4vD4ZkC0mDyrOA==",
       "requires": {
         "debug": "^4.1.1",
         "get-symbol-from-current-process-h": "^1.0.2",
-        "node-addon-api": "^2.0.0",
+        "node-addon-api": "^3.0.0",
         "node-gyp-build": "^4.2.1"
       },
       "dependencies": {
@@ -2471,18 +2405,13 @@
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "node-addon-api": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-          "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
         }
       }
     },
     "ref-struct-di": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.0.tgz",
-      "integrity": "sha512-gghZITj/iQwdwFDduZ6T8kL2B2ogInlOz7AOB0ggFoEc7akAKMcDrbzh3OIPk13Kxy8U2bHPvN6nejcBh4jN7A==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ref-struct-di/-/ref-struct-di-1.1.1.tgz",
+      "integrity": "sha512-2Xyn/0Qgz89VT+++WP0sTosdm9oeowLP23wRJYhG4BFdMUrLj3jhwHZNEytYNYgtPKLNTP3KJX4HEgBvM1/Y2g==",
       "requires": {
         "debug": "^3.1.0"
       }

--- a/ffi/node/package.json
+++ b/ffi/node/package.json
@@ -21,8 +21,8 @@
   "license": "ISC",
   "dependencies": {
     "ffi-napi": "4.0.3",
-    "ref-array-napi": "1.2.1",
-    "ref-napi": "3.0.2"
+    "ref-array-napi": "1.2.2",
+    "ref-napi": "3.0.3"
   },
   "devDependencies": {
     "@types/chai": "4.2.7",


### PR DESCRIPTION
Currently, Signal Desktop has [some explicit resolutions](https://github.com/signalapp/Signal-Desktop/blob/752245db4a45d53266430cd41a4ee00df0aee475/package.json#L293-L295) to bump `node-addon-api` from 2.0.0 to 2.0.1.

https://github.com/node-ffi-napi/ref-napi/pull/44#issuecomment-850978137 and https://github.com/Janealter/ref-array-napi/pull/2 have been merged now, which bumps `node-addon-api` to 3+. This should also eliminate the need for the Signal team to set those aforementioned explicit resolutions.

This PR is also needed to get Signal Desktop to build properly on [Windows ARM64](https://github.com/signalapp/Signal-Desktop/issues/3745) 👍🏼 

CC @scottnonnenberg-signal who added the resolutions in https://github.com/signalapp/Signal-Desktop/commit/4ce4569afb47ec917c1a5c772f65a6cee15d95c4