### PR TITLE
Allow building on arm64 linux

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -17,7 +17,10 @@ jobs:
       - name: Install pre-requisites
         run: |
           cargo install --version=1.0.0 cargo-ndk
-          rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
+          rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android aarch64-unknown-linux-gnu
+          dpkg --add-architecture arm64
+          apt update
+          apt install -y libc6-dev:arm64 gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
 
       - name: Build Android
         run: |
@@ -41,12 +44,23 @@ jobs:
         with:
           node-version: '${{ steps.node_version.outputs.NODE_VERSION }}'
 
-      - name: Build Linux
+      - name: Build Linux x64
         working-directory: ffi/node
         run: |
           npm --version
           node --version
           make libzkgroup
+
+      - name: Build Linux arm64
+        working-directory: ffi/node
+        run: |
+          npm --version
+          node --version
+          make libzkgroup
+        env:
+          NODE_ARCH: arm64
+          CARGO_TARGET: aarch64-unknown-linux-gnu
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
 
       - name: Upload Android
         uses: svenstaro/upload-release-action@v1-release
@@ -57,12 +71,21 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
 
-      - name: Upload Linux
+      - name: Upload Linux x64
         uses: svenstaro/upload-release-action@v1-release
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ffi/node/libzkgroup-x64.so
           asset_name: libzkgroup-x64.so
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload Linux arm64
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ffi/node/libzkgroup-arm64.so
+          asset_name: libzkgroup-arm64.so
           tag: ${{ github.ref }}
           overwrite: true
 

--- a/ffi/node/BUILDING.md
+++ b/ffi/node/BUILDING.md
@@ -41,6 +41,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 `rustup show` should indicate that the `x86_64-unknown-linux-gnu` is the host and stable, active toolchain.
 
+For arm64 cross compiles, the `libc6-dev:arm64`, `gcc-aarch64-linux-gnu` and `binutils-aarch64-linux-gnu` packages are required as well as the `aarch64-unknown-linux-gnu` rust target.
+
 ### Mac
 Install Rust.
 
@@ -95,6 +97,12 @@ If all tests pass, go to the packaging step.
 You can manually build the library by going to the project root and running a cargo command. For example, to build a debug library:
 ```
 cargo build
+```
+
+### Cross Building
+To cross build for arm64, from this directory run:
+```sh 
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/aarch64-linux-gnu-gcc NODE_ARCH=arm64 CARGO_BUILD_TARGET="aarch64-unknown-linux-gnu" make libzkgroup
 ```
 
 ## Packaging

--- a/ffi/node/Makefile
+++ b/ffi/node/Makefile
@@ -1,7 +1,8 @@
 ZKGROUP_RUST_DIR=../../rust
 ZKGROUP_TARGET_DIR=../../target
 
-NODE_ARCH := $(shell node -p "process.arch" || echo x64)
+NODE_ARCH ?= $(shell node -p "process.arch" || echo x64)
+
 
 ifeq ($(OS),Windows_NT)
 	DETECTED_OS := Windows

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2021-09-19"
+channel = "nightly-2021-09-16"
 components = [
     "rust-src",
 ]
@@ -17,4 +17,5 @@ targets = [
 #    "x86_64-apple-ios-macabi",
     "x86_64-linux-android",
     "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
 ]


### PR DESCRIPTION
This adds the ability to cross-compile zkgroup for arm64 linux. The
changes are explained as:
* rust-toolchain: add aarch64 linux target and work around an arm64 bug
  in the nightly-2021-09-16 channel. These changes alone are enough for
  compiling on arm64, but not cross-compiling.
* ffi/node/Makefile: allow passing in the target build arch to allow
  cross compiling to arm64.
* workflows/artifacts: Enables building of arm64 binaries in Github
  actions.